### PR TITLE
Add authorization support for upload requests

### DIFF
--- a/Sources/LoggingELK/LogstashLogHandler+HTTPFormatting.swift
+++ b/Sources/LoggingELK/LogstashLogHandler+HTTPFormatting.swift
@@ -54,6 +54,10 @@ extension LogstashLogHandler {
         }
 
         // Set headers that always stay consistent over all requests
+        if let authorization = self.authorization {
+            httpRequest.headers.add(name: "Authorization", value: authorization.value)
+        }
+        
         httpRequest.headers.add(name: "Content-Type", value: "application/json")
         httpRequest.headers.add(name: "Accept", value: "application/json")
         // Keep-alive header to keep the connection open

--- a/Sources/LoggingELK/LogstashLogHandler.swift
+++ b/Sources/LoggingELK/LogstashLogHandler.swift
@@ -91,6 +91,7 @@ public struct LogstashLogHandler: LogHandler {
     public static func setup(hostname: String,
                              port: Int,
                              useHTTPS: Bool = false,
+                             authorization: Authorizable? = nil,
                              eventLoopGroup: EventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: (System.coreCount != 1) ? System.coreCount / 2 : 1),
                              backgroundActivityLogger: Logger = Logger(label: "backgroundActivity-logstashHandler"),
                              uploadInterval: TimeAmount = TimeAmount.seconds(3),
@@ -103,6 +104,7 @@ public struct LogstashLogHandler: LogHandler {
         Self.hostname = hostname
         Self.port = port
         Self.useHTTPS = useHTTPS
+        Self.authorization = authorization
         Self.eventLoopGroup = eventLoopGroup
         Self.backgroundActivityLogger = backgroundActivityLogger
         Self.uploadInterval = uploadInterval

--- a/Sources/LoggingELK/LogstashLogHandler.swift
+++ b/Sources/LoggingELK/LogstashLogHandler.swift
@@ -22,6 +22,8 @@ public struct LogstashLogHandler: LogHandler {
     static var port: Int?
     /// Specifies if the HTTP connection to Logstash should be encrypted via TLS (so HTTPS instead of HTTP)
     static var useHTTPS: Bool?
+    /// Specifies  the authorization schema for the HTTP request
+    static var authorization: Authorizable?
     /// The `EventLoopGroup` which is used to create the `HTTPClient`
     static var eventLoopGroup: EventLoopGroup?
     /// Used to log background activity of the `LogstashLogHandler` and `HTTPClient`

--- a/Sources/LoggingELK/Utils/Authorization.swift
+++ b/Sources/LoggingELK/Utils/Authorization.swift
@@ -1,0 +1,45 @@
+//
+//  Authentication.swift
+//  
+//
+//  Created by Oleg Bragin on 09.11.2022.
+//
+
+import Foundation
+
+/// Describes the property which should be used to set the authorization header
+/// to access a remote resource
+public protocol Authorizable {
+    /// Should return authorization header value.
+    var value: String { get }
+}
+
+/// Defines the most commonly used authroization type names: Basic and Bearer
+/// Basically define the first part of overall Authorization header value, e.g.:
+/// `Basic <token>`, etc.
+public enum AuthorizationType: String {
+    case basic
+    case bearer
+    
+    public var name: String {
+        switch self {
+        case .basic:
+            return "Basic"
+        case .bearer:
+            return "Bearer"
+        }
+    }
+}
+
+/// Defines the default way of providing the authorization header to caller
+public struct Authorization: Authorizable {
+    /// Type of authorization
+    let type: AuthorizationType
+    /// Token string, which should generated outside
+    let token: String
+    
+    /// A string concatenated from type name and token itself for authroization header field
+    public var value: String {
+        return "\(type.name) \(token)"
+    }
+}


### PR DESCRIPTION
# Add authorization support for upload requests

## :recycle: Current situation
When creating HTTP request for uploading the logs, there is no way to provide authorisation type for a request.

## :bulb: Proposed solution
Extend the whole solution with authorisation support by providing an extra property to initialiser (setup) method

### Problem that is solved
Allows to support log stash instances which are behind the authorisation
