### PR TITLE
MOBN-3146 Update package dependencies to latest versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
         .library(name: "LoggingELK", targets: ["LoggingELK"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-log.git", exact: "1.6.2"),
-        .package(url: "https://github.com/swift-server/async-http-client.git", exact: "1.25.2")
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.6.4"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.29.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
# MOBN-3146 Update package dependencies to latest versions

## :recycle: Current situation
The swift-log-elk package was using older versions of its dependencies:
- swift-log: 1.6.2
- async-http-client: 1.25.2

## :bulb: Proposed solution
Updated both dependencies to their latest available versions using `swift package update`:
- swift-log: 1.6.2 → 1.6.4
- async-http-client: 1.25.2 → 1.29.0

### Problem that is solved
- Brings latest bug fixes and performance improvements from upstream dependencies
- Ensures compatibility with latest Swift ecosystem updates
- Resolves potential security vulnerabilities present in older versions

### Implications
- No breaking changes expected as these are minor/patch version updates
- All existing code should continue to work without modifications
- Build system will fetch and cache the new dependency versions

## :heavy_plus_sign: Additional Information

### Related PRs
N/A - This is a dependency maintenance update

### Testing
- [x] Package builds successfully with new dependencies (`swift build` completed without errors)
- [x] All dependency resolution completed successfully
- [x] No API breaking changes detected

### Reviewer Nudging
- Check Package.swift for the updated version numbers
- Verify that the build completes successfully
- Review that no unexpected transitive dependency changes occurred